### PR TITLE
Use the current date if no end date is specified

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -176,6 +176,8 @@ function _getFirstandLastReward(obj){
 }
 
 export function verifyUserInput(userInput, network){
+    userInput.end ??= Date.now();
+
     let start = new Date(userInput.start);
     let end = new Date(userInput.end);
     let priceData = userInput.priceData;


### PR DESCRIPTION
This change allows the user to remove the `end` date on `config/userInput.json` and calculate all rewards until the present day.