### PR TITLE
fixed the corner case of having exactly a multiple of 100 staking events

### DIFF
--- a/src/curl.js
+++ b/src/curl.js
@@ -28,7 +28,7 @@ export async function addStakingData(obj){
         stakingObject = await getStakingObject(address, page, network);
 
         // Break loop if none rewards have been found for the address.
-        if(stakingObject.data.count == 0 || stakingObject.data.list.length == 0){
+        if(stakingObject.data.count == 0 || stakingObject.data.list === null){
             break;
         }
 


### PR DESCRIPTION
It might be that subscan changed their API. Having an address which had exactly a multiple of 100 of staking rewards broke the code recently. Previously, as far as I remember, that should have been fixed with @maciejhirsz PR. But maybe subscan changed something to their API and parsing an address caused this error:

![image_2](https://user-images.githubusercontent.com/67730419/111768924-dab35080-88a8-11eb-9377-be0f94a0a69f.png)

I fixed the issue by not checking for the length of the list, but rather checking if it is null.