### PR TITLE
add API rate limit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## Version 1.4.6
+* Added a small delay to avoid triggering API rate limit
 ## Version 1.4.5
 * Added sum of fiat value in console output (based on daily prices).
 ## Version 1.4.4

--- a/src/curl.js
+++ b/src/curl.js
@@ -1,9 +1,10 @@
 import curl from 'curlrequest';
 import { exportVariable } from './fileWorker.js';
-import { dateToString, transformDDMMYYYtoUnix, min } from './utils.js';
+import { dateToString, transformDDMMYYYtoUnix, min, sleep } from './utils.js';
 
 
 export async function addStakingData(obj){
+    const SLEEP_DELAY=100
     let found = 0;
     let stakingObject = {};
     var finished;
@@ -26,6 +27,8 @@ export async function addStakingData(obj){
         page += 1;
         round += 1;
         stakingObject = await getStakingObject(address, page, network);
+        // Delay to avoid hitting API rate limit
+        await sleep(SLEEP_DELAY)
 
         // Break loop if none rewards have been found for the address.
         if(stakingObject.data.count == 0 || stakingObject.data.list === null){

--- a/src/curl.js
+++ b/src/curl.js
@@ -4,7 +4,7 @@ import { dateToString, transformDDMMYYYtoUnix, min, sleep } from './utils.js';
 
 
 export async function addStakingData(obj){
-    const SLEEP_DELAY=100
+    const SLEEP_DELAY=100;
     let found = 0;
     let stakingObject = {};
     var finished;
@@ -28,7 +28,7 @@ export async function addStakingData(obj){
         round += 1;
         stakingObject = await getStakingObject(address, page, network);
         // Delay to avoid hitting API rate limit
-        await sleep(SLEEP_DELAY)
+        await sleep(SLEEP_DELAY);
 
         // Break loop if none rewards have been found for the address.
         if(stakingObject.data.count == 0 || stakingObject.data.list === null){

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,9 @@
 import { round, pow } from 'mathjs';
 
+export function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
 export function dateToString(date){
     let day = date.getDate().toString();
     let month = (date.getMonth() + 1).toString();


### PR DESCRIPTION
Subscan implemented an API rate limit which causes rewards calculation to fail.

{ message: 'API rate limit exceeded' }
TypeError: Cannot read property 'count' of undefined

