### PR TITLE
fix: Update input verification error message

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -186,7 +186,7 @@ export function verifyUserInput(userInput){
     }
 
     if(end > new Date()){
-        throw new Error('Start date is in the future.');
+        throw new Error('End date is in the future.');
     }
 }
 


### PR DESCRIPTION
**Overview:**
This pull request updates the `verifyUserInput()` function such that the 'end date' error message is correct.