### PR TITLE
More networks support and add subscan apikey config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-config/
+config/userInput.json
 node_modules
 *.json
 *.csv

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ For all changes see the changelog.md
 ```bash
 git clone git@github.com:w3f/staking-rewards-collector.git
 cd staking-rewards-collector
-Change the parameters inside the config/userInput.json to your needs.
+cp config/userInput.json.sample config/userInput.json
+// Change the parameters inside the config/userInput.json to your needs.
 yarn
 yarn start
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Staking Rewards:
 * **startBalance**: The amount of tokens from which the staking rewards are generated at the time of the `start`. Used to calculate the annualizedReturn, can be set to any number if the user is not interested in an accurate annualized return metric.
 * **start** (YYYY-MM-DD): The earliest day you want to analyze. Note that the earliest available prices: Polkadot (2020-08-19), Kusama (2019-09-20) Moonriver (2021-08-26), Moonbeam (2022-01-11), Shiden (2021-08-30), Astar (2022-01-17), Centrifuge (2022-07-13), KILT (2021-12-01). Prices are set to 0 before that.
 * **end** (YYYY-MM-DD): The most recent day you want to analyze.
+* **subscan_apikey**: You can apply for a developer apikey from [subscan.io](https://support.subscan.io/#introduction) to skip api call rate limit.
 
 
 Price Data:

--- a/config/userInput.json.sample
+++ b/config/userInput.json.sample
@@ -20,3 +20,4 @@
         "network": "Polkadot"
     }
 ]}
+

--- a/config/userInput.json.sample
+++ b/config/userInput.json.sample
@@ -5,6 +5,7 @@
 "priceData": "true",
 "exportOutput": "true",
 "exportPrefix": "out/",
+"subscan_apikey": "",
 "addresses": [
     {
         "name": "Account 1",

--- a/src/gatherData.js
+++ b/src/gatherData.js
@@ -3,14 +3,14 @@ import { makeDaysArray, initializeObject } from "./utils.js";
 import { addStakingData } from './curl.js';
 
 export async function gatherData(
-    start, end, network, name, address, currency, priceData, startBalance, ticker
+    start, end, network, name, address, currency, priceData, startBalance, ticker, subscan_apikey
 ) {
    
     let obj = {};
     let daysArray = [];
 
     daysArray = makeDaysArray(new Date(start), new Date(end));
-    obj = initializeObject(daysArray, network, name, address, currency, startBalance, ticker);
+    obj = initializeObject(daysArray, network, name, address, currency, startBalance, ticker, subscan_apikey);
     if(priceData == 'true'){
         obj = await addPriceData(obj);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,9 @@ async function main () {
     let exportOutput = userInput.exportOutput;
     let startBalance = userInput.addresses[i].startBalance;
     let ticker = getTicker(network);
+    let subscan_apikey = userInput.subscan_apikey;
 
-    obj = await gatherData(start, end, network, addressName, address, currency, priceData, startBalance, ticker);
+    obj = await gatherData(start, end, network, addressName, address, currency, priceData, startBalance, ticker, subscan_apikey);
 
     // otherwise there were no rewards
     if (obj.data.numberRewardsParsed > 0) {

--- a/src/networks.js
+++ b/src/networks.js
@@ -57,6 +57,24 @@ export function getNetworkInfo() {
 			normalization: 1 / 1e15,
 			minTime: 1638342000000
 		},
+		'crab' : {
+			ticker: 'CRAB',
+			coinGeckoOverride: 'darwinia-crab-network',
+			normalization: 1 / 1e9,
+			minTime: 1638342000000
+		},
+		'darwinia' : {
+			ticker: 'RING',
+			coinGeckoOverride: 'darwinia-network-native-token',
+			normalization: 1 / 1e9,
+			minTime: 1638342000000
+		},
+		'edgeware' : {
+			ticker: 'EDG',
+			coinGeckoOverride: 'edgeware',
+			normalization: 1 / 1e18,
+			minTime: 1638342000000
+		},
 	}
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ export function makeDaysArray(startDate, endDate) {
   };
 
 export function initializeObject(
-    daysArray, network, name, address, currency, startBalance, ticker
+    daysArray, network, name, address, currency, startBalance, ticker, subscan_apikey
 ) {
     let obj = {
         'message': 'empty',
@@ -51,6 +51,7 @@ export function initializeObject(
         'currentValueRewardsFiat':0,
         'totalAmountHumanReadable':0,
         'totalValueFiat': 0,
+        'subscan_apikey': subscan_apikey,
         'data':{
             'numberRewardsParsed': 0,
             'numberOfDays': daysArray.length,


### PR DESCRIPTION
1. added 3 more networks (edgeware, crab, and darwinia)
2. put a `userInput.json.sample` in the config folder
3. add a `subscan_apikey` config item and update methods to support it.  Leaving the item blank works as it did.