### PR TITLE
Do not try to create directory if "" (null)

### DIFF
--- a/src/fileWorker.js
+++ b/src/fileWorker.js
@@ -33,7 +33,9 @@ export function writeOutput(fname, data) {
   let outputDir = userInput.exportPrefix === undefined ? "" : userInput.exportPrefix;
 
   try {
-    createOutputDir(outputDir);
+    if (outputDir != "") {
+      createOutputDir(outputDir);
+    }
     fs.writeFileSync(outputDir + fname, data);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Currently this fails (with ENOENT) if a subdirectory to write is not specified. This just adds a check so it does not try to create the subdirectory if not specified.