### PR TITLE
handle entries on a per-payout basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Staking Rewards Collector v1.6.3
+# Staking Rewards Collector v1.7.0
 
 # Disclaimer
 Everyone using this tool does so at his/her own risk. Neither I nor Web3 Foundation guarantee that any data collected is valid and every user is responsible for double-checking the results of this tool. In addition to potential bugs in this code, you are relying on third-party data: Subscan's API is used to collect staking data and CoinGecko's API is used to collect daily price data.
@@ -6,10 +6,9 @@ Everyone using this tool does so at his/her own risk. Neither I nor Web3 Foundat
 **This is no tax advice**: Every user is responsible to do his/her own research about how stake rewards are taxable in his/her regulatory framework.
 
 # Changelog
-## Version 1.6.3
-* It is now possible to add a subscan API key to skip call rate limits. If you do not have a key, just leave empty.
-* More supported networks (edgeware, crab, and darwinia)
-* Small bugfix with creation of output folder.
+## Version 1.7.0
+* Changed format of the account-level csv-outputs. We switched from a "per-day" format to a "per-payout" format to get more granular information. (thanks to rphmeier)
+* Fixed a small bug with timestamps and a function that lead the script to try to access unavailable prices leading to a "price undefined" error.
 
 Thanks to the contributors.
 
@@ -61,7 +60,7 @@ Output:
 After the tool executed successfully, it creates two files in the root folder. The JSON file contains some meta-data (e.g., sum of rewards and estimate of annualized return rate) and the CSV file gives the most important information in a table and thereby printable format.
 
 ### CSV Output
-The CSV output file contains a row for every day within the time frame where at least one staking reward occurred. Other days are excluded. Example output:
+The CSV output file contains a row for every payout within the time frame where at least one staking reward occurred. Example output:
 
 https://i.imgur.com/4LCsDOc.png
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Everyone using this tool does so at his/her own risk. Neither I nor Web3 Foundat
 # Changelog
 ## Version 1.7.0
 * Changed format of the account-level csv-outputs. We switched from a "per-day" format to a "per-payout" format to get more granular information. (thanks to rphmeier)
+* Added the EventID of each staking reward to the csv-outputs.
 * Fixed a small bug with timestamps and a function that lead the script to try to access unavailable prices leading to a "price undefined" error.
 
 Thanks to the contributors.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## Version 1.6.3
+* It is now possible to add a subscan API key to skip call rate limits. If you do not have a key, just leave empty.
+* More supported networks (edgeware, crab, and darwinia)
+* Small bugfix with creation of output folder.
 ## Version 1.6.2
 * Some code refactoring and under-the-hood improvements to make it easier to add additional networks in the future. (thanks to joepetrowski)
 * Fixed bug that caused issues when creating a custom-named output folder.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staking-rewards-collector",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "main": "src/index.js",
   "repository": "git@github.com:w3f/staking-rewards-collector.git",
   "author": "Jonas Gehrlein <jonas@web3.foundation>",

--- a/src/api.js
+++ b/src/api.js
@@ -41,10 +41,10 @@ async function _getPriceObject(obj){
         } catch (e){
             console.log('Error in parsing CoinGecko Data' + e);
         }
-    if(priceObject.success == false){
+
+    if(priceObject.success != true){
         throw new Error('The API request to CoinGecko was not successful. It returned the following message: ' + priceObject.message);       
     }
-
     return priceObject;
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -15,10 +15,22 @@ export async function addPriceData(obj){
     let i = _setIndex(obj);
 
     for(i;i<obj.data.list.length;i++){
+        let tmp = transformDDMMYYYtoUnix(obj.data.list[i].day); 
+        let priceEntry = prices.find(x => x.timestamp >= tmp);
 
-        let tmp = transformDDMMYYYtoUnix(obj.data.list[i].day);
-        obj.data.list[i].price = round(prices.find(x => x.timestamp == tmp).price,2);
-        obj.data.list[i].volume = total_volume.find(x => x.timestamp == tmp).volume;
+        // CoinGecko doesn't always provide all prices. Handle this and use last
+        // available price.
+        if (priceEntry == undefined) {
+            priceEntry = prices[prices.length - 1];
+        }
+
+        let volumeEntry = total_volume.find(x => x.timestamp >= tmp);
+        if (volumeEntry == undefined) {
+            volumeEntry = total_volume[total_volume.length - 1];
+        }
+
+        obj.data.list[i].price = round(priceEntry.price, 2);
+        obj.data.list[i].volume = volumeEntry.volume;
     }
     return obj;
 }

--- a/src/api.js
+++ b/src/api.js
@@ -52,6 +52,10 @@ async function _getPriceObject(obj){
         } catch (e){
             console.log('Error in parsing CoinGecko Data' + e);
         }
+    if(priceObject.success == false){
+        throw new Error('The API request to CoinGecko was not successful. It returned the following message: ' + priceObject.message);       
+    }
+
     return priceObject;
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -16,19 +16,8 @@ export async function addPriceData(obj){
 
     for(i;i<obj.data.list.length;i++){
         let tmp = transformDDMMYYYtoUnix(obj.data.list[i].day); 
-        let priceEntry = prices.find(x => x.timestamp >= tmp);
-
-        // CoinGecko doesn't always provide all prices. Handle this and use last
-        // available price.
-        if (priceEntry == undefined) {
-            priceEntry = prices[prices.length - 1];
-        }
-
+        let priceEntry = prices.find(x => x.timestamp >= tmp);       
         let volumeEntry = total_volume.find(x => x.timestamp >= tmp);
-        if (volumeEntry == undefined) {
-            volumeEntry = total_volume[total_volume.length - 1];
-        }
-
         obj.data.list[i].price = round(priceEntry.price, 2);
         obj.data.list[i].volume = volumeEntry.volume;
     }

--- a/src/curl.js
+++ b/src/curl.js
@@ -90,6 +90,7 @@ function checkIfEnd(stakingObj, lastDay, loopIndex){
 }
 
 async function getStakingObject(address, page, network, subscan_apikey){
+
     const SLEEP_DELAY=100;
     
     let breakPoint = 0;
@@ -122,14 +123,13 @@ async function getStakingObject(address, page, network, subscan_apikey){
             } catch(e) {
                 breakPoint += 1;
             }
-
-        if (stakingObject.message == 'API rate limit exceeded') {
-            // Delay to avoid hitting API rate limit
-            await sleep(SLEEP_DELAY);
-            continueLoop = true;
-        }
     }
-    return stakingObject;
+
+    if(stakingObject.message != 'Success'){
+        throw new Error("The Subscan API returned the following error: "+ stakingObject.message);
+    }
+    
+   return stakingObject;
 }
 
 async function curlRequest(options){

--- a/src/curl.js
+++ b/src/curl.js
@@ -40,30 +40,27 @@ export async function addStakingData(obj){
         } else {
             loopIndex = min(stakingObject.data.count - page*100,100);
         }
+
         for(let i=0; i < obj.data.numberOfDays; i++){
             for(let x = 0; x < loopIndex; x++){
                 let tmp = dateToString(new Date(stakingObject.data.list[x].block_timestamp * 1000));
-                    if(tmp == obj.data.list[i].day & stakingObject.data.list[x].event_id == "Reward"){
-                        found += 1;
-                        // if we already filled out the entries of a specific day. We then just concanate strings or add values.
-                        if(obj.data.list[i].numberPayouts >= 1){
-                            obj.data.list[i].amountPlanks = obj.data.list[i].amountPlanks + parseInt(stakingObject.data.list[x].amount);
-                            obj.data.list[i].numberPayouts = obj.data.list[i].numberPayouts + 1;
-                            obj.data.list[i].blockNumber = obj.data.list[i].blockNumber + ' and ' + stakingObject.data.list[x].block_num;
-                            obj.data.list[i].extrinsicHash = obj.data.list[i].extrinsicHash + ' and ' + stakingObject.data.list[x].extrinsic_hash;
-                        // if an entry has only the default values we add the ones from the staking object.
-                        } else {
-                            obj.data.list[i].amountPlanks = parseInt(stakingObject.data.list[x].amount);
-                            obj.data.list[i].numberPayouts = obj.data.list[i].numberPayouts + 1;
-                            obj.data.list[i].blockNumber = stakingObject.data.list[x].block_num;
-                            obj.data.list[i].extrinsicHash = stakingObject.data.list[x].extrinsic_hash;
-                        }
-                    }
+                if(tmp == obj.data.list[i].day & stakingObject.data.list[x].event_id == "Reward"){
+                    found += 1;
+
+                    let amountPlanks = parseInt(stakingObject.data.list[x].amount);
+                    obj.data.list[i].payouts.push({
+                        amountPlanks: amountPlanks,
+                        blockNumber: stakingObject.data.list[x].block_num,
+                        extrinsicHash: stakingObject.data.list[x].extrinsicHash,
+                        timestamp: stakingObject.data.list[x].block_timestamp,
+                    });
+
+                    obj.data.list[i].amountPlanks += amountPlanks;
                 }
             }
+        }
         finished = checkIfEnd(stakingObject, obj.data.list[0].day, loopIndex);
     } while (finished == false);
-
 
     obj.data.numberRewardsParsed = found;
 
@@ -93,6 +90,8 @@ function checkIfEnd(stakingObj, lastDay, loopIndex){
 }
 
 async function getStakingObject(address, page, network, subscan_apikey){
+    const SLEEP_DELAY=100;
+    
     let breakPoint = 0;
     let continueLoop = true;
 
@@ -123,6 +122,12 @@ async function getStakingObject(address, page, network, subscan_apikey){
             } catch(e) {
                 breakPoint += 1;
             }
+
+        if (stakingObject.message == 'API rate limit exceeded') {
+            // Delay to avoid hitting API rate limit
+            await sleep(SLEEP_DELAY);
+            continueLoop = true;
+        }
     }
     return stakingObject;
 }

--- a/src/curl.js
+++ b/src/curl.js
@@ -53,6 +53,7 @@ export async function addStakingData(obj){
                         blockNumber: stakingObject.data.list[x].block_num,
                         extrinsicHash: stakingObject.data.list[x].extrinsicHash,
                         timestamp: stakingObject.data.list[x].block_timestamp,
+                        eventIndex: stakingObject.data.list[x].event_index,
                     });
 
                     obj.data.list[i].amountPlanks += amountPlanks;
@@ -128,7 +129,7 @@ async function getStakingObject(address, page, network, subscan_apikey){
     if(stakingObject.message != 'Success'){
         throw new Error("The Subscan API returned the following error: "+ stakingObject.message);
     }
-    
+
    return stakingObject;
 }
 

--- a/src/fileWorker.js
+++ b/src/fileWorker.js
@@ -54,13 +54,26 @@ export function writeCSV(obj, fname) {
 
 function extractAsCSV(obj) {
   const header = [
-    `Prices from CoinGecko & Staking Rewards from Subscan.io\n` +
-    `Day,Price in ${obj.currency},Daily Volume in ${obj.currency},Staking Rewards in ${obj.ticker},Number of Payouts,Value in Fiat`
-  ];
+    "Prices from CoinGecko & Staking Rewards from Subscan.io \n" +
+      "Day, Price in " + obj.currency +
+      ", Daily Volume in " + obj.currency +  
+      ", Staking Rewards in " + obj.ticker + 
+      ", Payout Block Number" +
+      ", Payout Block Timestamp" +
+      ", Value in Fiat" 
+  ]; 
+  
+  let rows = [];
 
-  const rows = obj.data.list
-    .filter(entry => entry.numberPayouts > 0)
-    .map(entry => `${entry.day}, ${entry.price}, ${entry.volume}, ${entry.amountHumanReadable}, ${entry.numberPayouts}, ${entry.valueFiat}`);
+  for (let d=0; d<obj.data.list.length; d++) {
+    let day = obj.data.list[d];
+
+    let dayRows = day.payouts
+      .filter(payout => payout.amountPlanks > 0)
+      .map(entry => `${day.day}, ${day.price}, ${day.volume}, ${entry.amountHumanReadable}, ${entry.blockNumber}, ${entry.timestamp}, ${entry.valueFiat}`);
+
+    rows.push(...dayRows);
+  }
 
   return header.concat(rows).join("\n");
 }

--- a/src/fileWorker.js
+++ b/src/fileWorker.js
@@ -61,7 +61,7 @@ function extractAsCSV(obj) {
       ", Payout Block Number" +
       ", Payout Block Timestamp" +
       ", Value in Fiat" +
-      ", Extrinsic Hash"
+      ", EventID"
   ]; 
   
   let rows = [];

--- a/src/fileWorker.js
+++ b/src/fileWorker.js
@@ -60,7 +60,8 @@ function extractAsCSV(obj) {
       ", Staking Rewards in " + obj.ticker + 
       ", Payout Block Number" +
       ", Payout Block Timestamp" +
-      ", Value in Fiat" 
+      ", Value in Fiat" +
+      ", Extrinsic Hash"
   ]; 
   
   let rows = [];
@@ -70,7 +71,7 @@ function extractAsCSV(obj) {
 
     let dayRows = day.payouts
       .filter(payout => payout.amountPlanks > 0)
-      .map(entry => `${day.day}, ${day.price}, ${day.volume}, ${entry.amountHumanReadable}, ${entry.blockNumber}, ${entry.timestamp}, ${entry.valueFiat}`);
+      .map(entry => `${day.day}, ${day.price}, ${day.volume}, ${entry.amountHumanReadable}, ${entry.blockNumber}, ${entry.timestamp}, ${entry.valueFiat}, ${entry.eventIndex}`);
 
     rows.push(...dayRows);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -90,5 +90,4 @@ async function main () {
   console.log('The total value of all payouts is ' + totalFiat + ' ' + obj.currency + ' (based on daily prices).');
   console.log('For more information, open the CSV file(s) or copy the content of the JSON file(s) into http://jsonviewer.stack.hu/ (click format).');
 }
-
 main().catch(console.error).finally(() => process.exit());

--- a/src/networks.js
+++ b/src/networks.js
@@ -5,7 +5,7 @@
  * ticker:            The commonly accepted ticker for a network's token.
  * normalization:     The multiplier on returned balances for user display. Often called "decimals".
  *                    This parameter is in the inverse, i.e. `1 / 10 ** decimals`.
- * minTime:           The UNIX timestamp before which there is no price data. Helps avoid
+ * minTime:           The UNIX timestamp (in seconds) before which there is no price data. Helps avoid
  *                    unnecessary API calls.
  * coinGeckoOverride: (Optional) Sometimes the Coin Gecko API requires a name that differs from
  *                    network.
@@ -17,63 +17,63 @@ export function getNetworkInfo() {
 		'polkadot' : {
 			ticker: 'DOT',
 			normalization: 1 / 1e10,
-			minTime: 1597708800000
+			minTime: 1597708800
 		},
 		'kusama' : {
 			ticker: 'KSM',
 			normalization: 1 / 1e12,
-			minTime: 1568851200000
+			minTime: 1568851200
 		},
 		'moonriver' : {
 			ticker: 'MOVR',
 			normalization: 1 / 1e18,
-			minTime: 1630022400000
+			minTime: 1630022400
 		},
 		'moonbeam' : {
 			ticker: 'GLMR',
 			normalization: 1 / 1e18,
-			minTime: 1641884400000
+			minTime: 1641884400
 		},
 		'astar' : {
 			ticker: 'ASTR',
 			normalization: 1 / 1e18,
-			minTime: 1642402800000
+			minTime: 1642402800
 		},
 		'shiden' : {
 			ticker: 'SDN',
 			normalization: 1 / 1e18,
-			minTime: 1630303200000
+			minTime: 1630303200
 		},
 		'centrifuge' : {
 			ticker: 'CFG',
 			coinGeckoOverride: 'wrapped-centrifuge',
 			normalization: 1 / 1e18,
-			minTime: 1626220800000
+			minTime: 1626220800
 		},
 		'kilt' : {
 			ticker: 'KILT',
 			coinGeckoOverride: 'kilt-protocol',
 			subscanOverride: 'spiritnet',
 			normalization: 1 / 1e15,
-			minTime: 1638342000000
+			minTime: 1638342000
 		},
 		'crab' : {
 			ticker: 'CRAB',
 			coinGeckoOverride: 'darwinia-crab-network',
 			normalization: 1 / 1e9,
-			minTime: 1638342000000
+			minTime: 1638342000
 		},
 		'darwinia' : {
 			ticker: 'RING',
 			coinGeckoOverride: 'darwinia-network-native-token',
 			normalization: 1 / 1e9,
-			minTime: 1638342000000
+			minTime: 1638342000
 		},
 		'edgeware' : {
 			ticker: 'EDG',
 			coinGeckoOverride: 'edgeware',
 			normalization: 1 / 1e18,
-			minTime: 1638342000000
+			minTime: 1638342000
 		},
 	}
 }
@@ -159,7 +159,7 @@ export function checkPriceAvailablilty(userInput, network) {
     let priceData = userInput.priceData;
     let end = new Date(userInput.end);
 
-    if (end.valueOf() < getNetworkTimeMinimum(network) & priceData == 'true') {
+    if ((end.valueOf() / 1000) < getNetworkTimeMinimum(network) & priceData == 'true') {
         console.log('Your requested time window lies before prices are available for ' + network.toUpperCase() + '. Switching off price data.');
         priceData = 'false';
     }

--- a/src/networks.js
+++ b/src/networks.js
@@ -149,6 +149,7 @@ export function getNetworkTimeMinimum(network) {
 	} else {
 		console.log(`${network.toUpperCase()} not in the database, returning all history.`)
 	}
+	return minTime;
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,12 +61,10 @@ export function initializeObject(
     for(let i = 0; i < daysArray.length; i++){
         obj.data.list[i] = {
             'day' : daysArray[i],
-            'blockNumber': '',
-            'extrinsicHash': '',
+            'payouts': [],
             'price': 0,
             'volume': 0,
             'amountPlanks': 0,
-            'numberPayouts':0,
             'amountHumanReadable': 0,
             'valueFiat':0
         }
@@ -125,6 +123,11 @@ export function calculateMetrics(obj) {
         obj.data.list[i].valueFiat = obj.data.list[i].amountHumanReadable * obj.data.list[i].price;
         obj.data.list[i].price = obj.data.list[i].price;
 
+        for(let j = 0; j < obj.data.list[i].payouts.length; j++) {
+            obj.data.list[i].payouts[j].amountHumanReadable = obj.data.list[i].payouts[j].amountPlanks * normalization;
+            obj.data.list[i].payouts[j].valueFiat = obj.data.list[i].payouts[j].amountHumanReadable * obj.data.list[i].price;
+        }
+
         // add values of each day to general metrics.
         obj.totalValueFiat = obj.totalValueFiat + obj.data.list[i].valueFiat;
         obj.totalAmountHumanReadable = obj.totalAmountHumanReadable + obj.data.list[i].amountHumanReadable;
@@ -162,15 +165,15 @@ function _getFirstandLastReward(obj) {
     var lastReward;
 
     while (i < max) {
-        if (obj.data.list[i].numberPayouts != 0) {
-            firstReward = obj.data.list[i].day;
+        if (obj.data.list[i].payouts.length != 0) {
+            firstReward = obj.data.list[i].day; 
             break;
         }
         i++;
     }
 
     while (x >= 0) {
-        if (obj.data.list[x].numberPayouts != 0) {
+        if (obj.data.list[x].payouts.length != 0) {    
            lastReward = obj.data.list[x].day;
             break;
         }


### PR DESCRIPTION
updated version of #40 .

This produces a CSV file where every non-zero payout gets its own row in the CSV file which includes the block number and timestamp - useful for mapping the output onto more fine-grained price APIs