### PR TITLE
Extend price api, add CryptoCompare endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Price Data:
 * **currency**: In what currency you would like to have your value expressed (allowed: "CHF", "USD", "EUR", "GBP" and others available at CoinGecko.com).
 * **priceData**: Do you want to look up price data for your specified range? (allowed: "true", "false").
 
+Price API:
+* The application currently supports two price data sources:
+    * CoinGecko API (default): has some limitations on the amount of historical data that can be fetched for free. 
+    * CryptoCompare API: has more generous free plan limits, currently with no limit on the historical data time range.
+* **priceApi**:
+    * `coingecko` will use the CoinGecko APIs
+    * `cryptocompare` will use the CryptoCompare API.
+
+
 Output:
 * **exportOutput**: Specify if you want the .csv and .json files to be exported (allowed: "true", "false").
 * **exportPrefix**: Specify a prefix appended to all files exported. (e.g. "out/" leads to all files being written in "out/")

--- a/src/gatherData.js
+++ b/src/gatherData.js
@@ -3,14 +3,14 @@ import { makeDaysArray, initializeObject } from "./utils.js";
 import { addStakingData } from './curl.js';
 
 export async function gatherData(
-    start, end, network, name, address, currency, priceData, startBalance, ticker, subscan_apikey, apiSleepDelay
+    start, end, network, name, address, currency, priceData, startBalance, ticker, subscan_apikey, apiSleepDelay, priceApi
 ) {
    
     let obj = {};
     let daysArray = [];
 
     daysArray = makeDaysArray(new Date(start), new Date(end));
-    obj = initializeObject(daysArray, network, name, address, currency, startBalance, ticker, subscan_apikey, apiSleepDelay);
+    obj = initializeObject(daysArray, network, name, address, currency, startBalance, ticker, subscan_apikey, apiSleepDelay, priceApi);
     obj = await addStakingData(obj);
     // There's no point in hitting the CoinGecko API if there are not any rewards.
     if (priceData == 'true' && obj.data.numberRewardsParsed > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ async function main () {
   let currency = userInput.currency;
   let exportOutput = userInput.exportOutput;
   let subscan_apikey = userInput.subscan_apikey;
+  let priceApi = userInput.priceApi;
   const apiSleepDelay = userInput.apiSleepDelay? userInput.apiSleepDelay: API_SLEEP_DELAY;
 
   for (let i = 0; i < userInput.addresses.length; i++) {
@@ -49,7 +50,7 @@ async function main () {
     let startBalance = userInput.addresses[i].startBalance;
     let ticker = getTicker(network);
 
-    obj = await gatherData(start, end, network, addressName, address, currency, priceData, startBalance, ticker, subscan_apikey, apiSleepDelay);
+    obj = await gatherData(start, end, network, addressName, address, currency, priceData, startBalance, ticker, subscan_apikey, apiSleepDelay, priceApi);
 
     // otherwise there were no rewards
     if (obj.data.numberRewardsParsed > 0) {
@@ -91,7 +92,7 @@ async function main () {
   console.log('\nThe following table lists all found rewards and values are expressed in ' + obj.currency + '.');
   console.log('\nRewards are calculated between ' + userInput.start + ' and ' + userInput.end + '.');
   console.table(tableArray);
-  console.log('The total value of all payouts is ' + totalFiat + ' ' + obj.currency + ' (based on daily prices).');
+  console.log('The total value of all payouts is ' + totalFiat + ' ' + obj.currency + ' (based on daily prices using ' + obj.priceApi + ' API).');
   console.log('For more information, open the CSV file(s) or copy the content of the JSON file(s) into http://jsonviewer.stack.hu/ (click format).');
 }
 main().catch(console.error).finally(() => process.exit());

--- a/src/priceApiServices.js
+++ b/src/priceApiServices.js
@@ -1,0 +1,93 @@
+import CoinGecko from "coingecko-api";
+import { getCoinGeckoName, getNetworkInfo } from "./networks.js";
+import { sleep } from "./utils.js";
+
+export const coingeckoService = {
+  async getPrices(obj, start, end) {
+    const CoinGeckoClient = new CoinGecko();
+    let priceObject;
+
+    try {
+      await sleep(100);
+      priceObject = await CoinGeckoClient.coins.fetchMarketChartRange(
+        getCoinGeckoName(obj.network),
+        {
+          from: start,
+          to: end,
+          vs_currency: obj.currency,
+        }
+      );
+
+      if (priceObject.success !== true) {
+        throw new Error(
+          "The API request to CoinGecko was not successful: " +
+            priceObject.message
+        );
+      }
+
+      return priceObject.data;
+    } catch (e) {
+      console.log("Error in parsing CoinGecko Data: " + e);
+      throw e;
+    }
+  },
+
+  /**
+   * Formats the price data received from the CoinGecko API.
+   * The CoinGecko API returns a list of arrays, where each array
+   * contains a timestamp and a value (either price or volume).
+   * This function converts the raw data into an array of objects
+   * with `timestamp` and the specified `key` (either "price" or "volume").
+   */
+  formatPriceData(data, key) {
+    const array = key === "price" ? data.prices : data.total_volumes;
+    return array.map((item) => ({
+      timestamp: item[0] / 1000,
+      [key]: item[1],
+    }));
+  },
+};
+
+export const cryptocompareService = {
+  async getPrices(obj, start, end) {
+    const baseUrl = "https://min-api.cryptocompare.com/data/v2/histoday";
+
+    const networkInfo = getNetworkInfo()[obj.network];
+    const ticker = networkInfo?.ticker || obj.network;
+    const numDays = Math.floor((end - start) / (24 * 3600)) + 1;
+
+    const url = `${baseUrl}?fsym=${ticker}&tsym=${obj.currency}&limit=${numDays}&toTs=${end}`;
+
+    try {
+      await sleep(100);
+      const response = await fetch(url);
+      const responseData = await response.json();
+
+      if (responseData.Response !== "Success") {
+        throw new Error(
+          "The API request to CryptoCompare was not successful: " +
+            responseData.Message
+        );
+      }
+
+      return responseData.Data.Data;
+    } catch (e) {
+      console.log("Error fetching CryptoCompare Data: " + e);
+      throw e;
+    }
+  },
+
+  /**
+   * Formats the price data received from the CryptoCompare API.
+   * The CryptoCompare API returns an array of objects, where each object
+   * has `time` and `close` (for price) or `volumeto` (for volume) properties.
+   * This function converts the raw data into an array of objects
+   * with `timestamp` and the specified `key` (either "price" or "volume").
+   */
+  formatPriceData(data, key) {
+    return data.map((item) => ({
+      timestamp: item.time,
+      [key]: key === "price" ? item.close : item.volumeto,
+    }));
+  },
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ export function makeDaysArray(startDate, endDate) {
   };
 
 export function initializeObject(
-    daysArray, network, name, address, currency, startBalance, ticker, subscan_apikey, apiSleepDelay
+    daysArray, network, name, address, currency, startBalance, ticker, subscan_apikey, apiSleepDelay, priceApi
 ) {
     let obj = {
         'message': 'empty',
@@ -53,6 +53,7 @@ export function initializeObject(
         'totalValueFiat': 0,
         'subscan_apikey': subscan_apikey,
         'apiSleepDelay': apiSleepDelay,
+        'priceApi': priceApi,
         'data':{
             'numberRewardsParsed': 0,
             'numberOfDays': daysArray.length,


### PR DESCRIPTION
+ Implemented support for the CryptoCompare API to fetch price data, in addition to the existing CoinGecko API integration.
+ Designed the price API integration in an extensible way to easily add support for more price data providers in the future.
+ Users can now choose between CoinGecko and CryptoCompare APIs based on their needs and the limitations of the free plans.